### PR TITLE
Implement map event editing

### DIFF
--- a/include/Editor/Components/CMakeLists.txt
+++ b/include/Editor/Components/CMakeLists.txt
@@ -2,4 +2,5 @@ target_sources(PeoplemonEditor PUBLIC
     EditMap.hpp
     HighlightRadioButton.hpp
     NewMapDialog.hpp
+    ScriptSelector.hpp
 )

--- a/include/Editor/Components/CMakeLists.txt
+++ b/include/Editor/Components/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(PeoplemonEditor PUBLIC
     EditMap.hpp
+    EventEditor.hpp
     HighlightRadioButton.hpp
     NewMapDialog.hpp
     ScriptSelector.hpp

--- a/include/Editor/Components/EditMap.hpp
+++ b/include/Editor/Components/EditMap.hpp
@@ -197,9 +197,31 @@ public:
      */
     void setWeather(core::map::Weather::Type weather);
 
+    /**
+     * @brief Set the OnEnter script
+     *
+     * @param script The script to run when the map is entered
+     */
     void setOnEnterScript(const std::string& script);
 
+    /**
+     * @brief Get the OnEnter script
+     *
+     */
+    const std::string& getOnEnterScript() const;
+
+    /**
+     * @brief Set the OnExit script
+     *
+     * @param script The script to run when the map is left
+     */
     void setOnExitScript(const std::string& script);
+
+    /**
+     * @brief Get the OnExit script
+     *
+     */
+    const std::string& getOnExitScript() const;
 
     void setAmbientLight(std::uint8_t lower, std::uint8_t upper, bool sunlight);
 
@@ -409,8 +431,7 @@ private:
     class SetWeatherAction;
     class SetYSortLayerAction;
     class SetTopLayerAction;
-    class SetEnterScriptAction;
-    class SetExitScriptAction;
+    class SetScriptAction;
     class SetAmbientLightAction;
     class AppendLevelAction;
     class ShiftLevelAction;

--- a/include/Editor/Components/EditMap.hpp
+++ b/include/Editor/Components/EditMap.hpp
@@ -225,10 +225,25 @@ public:
 
     void setAmbientLight(std::uint8_t lower, std::uint8_t upper, bool sunlight);
 
+    /**
+     * @brief Creates a new level
+     *
+     */
     void appendLevel();
 
+    /**
+     * @brief Shifts the given level up or down
+     *
+     * @param level The level to move
+     * @param up True for up, false for down
+     */
     void shiftLevel(unsigned int level, bool up);
 
+    /**
+     * @brief Removes the given level
+     *
+     * @param level The level to remove
+     */
     void removeLevel(unsigned int level);
 
     /**

--- a/include/Editor/Components/EditMap.hpp
+++ b/include/Editor/Components/EditMap.hpp
@@ -369,13 +369,35 @@ public:
 
     void removeLight(const sf::Vector2i& positionPixels);
 
+    /**
+     * @brief Creates a new map event
+     *
+     * @param event The event to create
+     */
     void createEvent(const core::map::Event& event);
 
+    /**
+     * @brief Returns a pointer to an event that overlaps the given position
+     *
+     * @param position The position to search
+     * @return const core::map::Event* Pointer to event or nullptr if none overlap
+     */
     const core::map::Event* getEvent(const sf::Vector2i& position);
 
+    /**
+     * @brief Alters the value of the given event
+     *
+     * @param orig Pointer to the event to update
+     * @param event New value to set
+     */
     void editEvent(const core::map::Event* orig, const core::map::Event& event);
 
-    void removeEvent(const sf::Vector2i& position);
+    /**
+     * @brief Deletes the given event
+     *
+     * @param event Pointer to the event to delete
+     */
+    void removeEvent(const core::map::Event* event);
 
     void addCatchZone(const core::map::CatchZone& zone);
 

--- a/include/Editor/Components/EventEditor.hpp
+++ b/include/Editor/Components/EventEditor.hpp
@@ -1,0 +1,62 @@
+#ifndef EDITOR_COMPONENTS_EVENTEDITOR_HPP
+#define EDITOR_COMPONENTS_EVENTEDITOR_HPP
+
+#include <BLIB/Interfaces/GUI.hpp>
+#include <Core/Maps/Map.hpp>
+#include <Editor/Components/ScriptSelector.hpp>
+
+namespace editor
+{
+namespace component
+{
+/**
+ * @brief Map event editor dialog
+ *
+ * @ingroup Components
+ *
+ */
+class EventEditor {
+public:
+    /// Callback called when an event is created or modified
+    using OnEdit = std::function<void(const core::map::Event*, const core::map::Event&)>;
+
+    /**
+     * @brief Construct a new Event Editor dialog
+     *
+     * @param onEdit Callback to call when an event is created or modified
+     */
+    EventEditor(const OnEdit& onEdit);
+
+    /**
+     * @brief Opens the dialog window and optionally populates with event info
+     *
+     * @param parent The parent GUI object
+     * @param source Optional event to populate from
+     * @param pos The position to populate if not editing an existing event
+     */
+    void open(const bl::gui::GUI::Ptr& parent, const core::map::Event* source,
+              const sf::Vector2i& pos);
+
+private:
+    const OnEdit onEdit;
+    const core::map::Event* orig;
+    bl::gui::GUI::Ptr parent;
+    bl::gui::Window::Ptr window;
+    bl::gui::Label::Ptr scriptLabel;
+    bl::gui::TextEntry::Ptr xInput;
+    bl::gui::TextEntry::Ptr yInput;
+    bl::gui::TextEntry::Ptr wInput;
+    bl::gui::TextEntry::Ptr hInput;
+    bl::gui::ComboBox::Ptr triggerSelect;
+
+    ScriptSelector scriptSelector;
+    void onScriptChosen(const std::string& s);
+
+    bool valid() const;
+    core::map::Event makeEvent() const;
+};
+
+} // namespace component
+} // namespace editor
+
+#endif

--- a/include/Editor/Components/ScriptSelector.hpp
+++ b/include/Editor/Components/ScriptSelector.hpp
@@ -1,0 +1,54 @@
+#ifndef EDITOR_COMPONENTS_SCRIPTSELECTOR_HPP
+#define EDITOR_COMPONENTS_SCRIPTSELECTOR_HPP
+
+#include <BLIB/Interfaces/GUI.hpp>
+#include <functional>
+
+namespace editor
+{
+namespace component
+{
+/**
+ * @brief GUI component for selecting or writing scripts. Performs syntax validation as well
+ *
+ * @ingroup Components
+ *
+ */
+class ScriptSelector {
+public:
+    /// Callback type for when a script is chosen
+    using OnSelect = std::function<void(const std::string&)>;
+
+    /**
+     * @brief Construct a new Script Selector dialog
+     *
+     * @param onSelect Callback to call when a script is chosen
+     */
+    ScriptSelector(const OnSelect& onSelect);
+
+    /**
+     * @brief Opens the dialog to select a script
+     *
+     * @param parent The parent to add the GUI elements to
+     * @param value The default script value to fill
+     */
+    void open(const bl::gui::GUI::Ptr& parent, const std::string& value = {});
+
+private:
+    const OnSelect onSelect;
+    bl::gui::Window::Ptr window;
+    bl::gui::TextEntry::Ptr scriptInput;
+    bl::gui::Label::Ptr errorLabel;
+    bool error;
+
+    bl::gui::FilePicker picker;
+    bl::gui::GUI::Ptr parent;
+    void onPick(const std::string& s);
+
+    void checkSyntax();
+};
+
+} // namespace component
+} // namespace editor
+
+#endif

--- a/include/Editor/Pages/Map.hpp
+++ b/include/Editor/Pages/Map.hpp
@@ -2,6 +2,7 @@
 #define EDITOR_PAGES_MAP_HPP
 
 #include <Editor/Components/NewMapDialog.hpp>
+#include <Editor/Components/ScriptSelector.hpp>
 #include <Editor/Pages/Page.hpp>
 #include <Editor/Pages/Subpages/Layers.hpp>
 #include <Editor/Pages/Subpages/Levels.hpp>
@@ -65,6 +66,7 @@ private:
     enum struct Tool {
         Metadata,
         MapEdit,
+        Events,
         Spawns,
         NPCs,
         Items,
@@ -87,6 +89,10 @@ private:
 
     bl::gui::FilePicker playlistPicker;
     void onChoosePlaylist(const std::string& file);
+
+    component::ScriptSelector scriptSelector;
+    bool choosingOnloadScript;
+    void onChooseScript(const std::string& script);
 
     void onMapClick(const sf::Vector2f& pixels, const sf::Vector2i& tiles);
     void onLevelChange(unsigned int level);

--- a/include/Editor/Pages/Map.hpp
+++ b/include/Editor/Pages/Map.hpp
@@ -1,6 +1,7 @@
 #ifndef EDITOR_PAGES_MAP_HPP
 #define EDITOR_PAGES_MAP_HPP
 
+#include <Editor/Components/EventEditor.hpp>
 #include <Editor/Components/NewMapDialog.hpp>
 #include <Editor/Components/ScriptSelector.hpp>
 #include <Editor/Pages/Page.hpp>
@@ -55,6 +56,10 @@ private:
     bl::gui::ComboBox::Ptr itemSpawnEntry;
     std::vector<core::item::Id> itemIdLookup;
 
+    bl::gui::RadioButton::Ptr createEventRadio;
+    bl::gui::RadioButton::Ptr editEventRadio;
+    bl::gui::RadioButton::Ptr deleteEventRadio;
+
     bl::gui::Label::Ptr onEnterLabel;
     bl::gui::Label::Ptr onExitLabel;
 
@@ -93,6 +98,9 @@ private:
     component::ScriptSelector scriptSelector;
     bool choosingOnloadScript;
     void onChooseScript(const std::string& script);
+
+    component::EventEditor eventEditor;
+    void onEventEdit(const core::map::Event* orig, const core::map::Event& event);
 
     void onMapClick(const sf::Vector2f& pixels, const sf::Vector2i& tiles);
     void onLevelChange(unsigned int level);

--- a/include/Editor/Pages/Subpages/MapArea.hpp
+++ b/include/Editor/Pages/Subpages/MapArea.hpp
@@ -7,14 +7,47 @@ namespace editor
 {
 namespace page
 {
+/**
+ * @brief Section of the map area with the map itself and related controls
+ *
+ * @ingroup Pages
+ *
+ */
 class MapArea {
 public:
+    /**
+     * @brief Construct a new Map Area
+     *
+     * @param clickCb Callback when the map itself is clicked
+     * @param syncCb Callback when the GUI should be updated
+     * @param systems The main game systems
+     */
     MapArea(const component::EditMap::PositionCb& clickCb,
             const component::EditMap::ActionCb& syncCb, core::system::Systems& systems);
 
+    /**
+     * @brief Returns the contained map
+     *
+     */
     component::EditMap& editMap();
 
+    /**
+     * @brief Returns the GUI element to pack
+     *
+     */
     bl::gui::Element::Ptr getContent();
+
+    /**
+     * @brief Disables the map controls when a dialog is opened or the map tab is inactive
+     *
+     */
+    void disableControls();
+
+    /**
+     * @brief Enables the map controls
+     *
+     */
+    void enableControls();
 
 private:
     bl::gui::Box::Ptr content;
@@ -23,6 +56,7 @@ private:
     bl::gui::Label::Ptr undoText;
     bl::gui::Button::Ptr redoBut;
     bl::gui::Label::Ptr redoText;
+    bl::gui::CheckButton::Ptr enableBut;
     component::EditMap::Ptr map;
 
     void refreshButtons();

--- a/src/Editor/Components/CMakeLists.txt
+++ b/src/Editor/Components/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(PeoplemonEditor PRIVATE
     EditMap.cpp
+    EventEditor.cpp
     HighlightRadioButton.cpp
     MapActions.hpp
     MapActions.cpp

--- a/src/Editor/Components/CMakeLists.txt
+++ b/src/Editor/Components/CMakeLists.txt
@@ -4,4 +4,5 @@ target_sources(PeoplemonEditor PRIVATE
     MapActions.hpp
     MapActions.cpp
     NewMapDialog.cpp
+    ScriptSelector.cpp
 )

--- a/src/Editor/Components/EditMap.cpp
+++ b/src/Editor/Components/EditMap.cpp
@@ -491,9 +491,22 @@ void EditMap::render(sf::RenderTarget& target, float residual,
         }
         break;
 
-    case RenderOverlay::Events:
-        // TODO
-        break;
+    case RenderOverlay::Events: {
+        static sf::Clock timer;
+        sf::RectangleShape area;
+        const std::uint8_t a =
+            static_cast<int>(timer.getElapsedTime().asSeconds()) % 2 == 0 ? 165 : 100;
+        area.setFillColor(sf::Color(0, 0, 0, a));
+        for (const auto& event : eventsField.getValue()) {
+            const auto& pos  = event.position.getValue();
+            const auto& size = event.areaSize.getValue();
+            area.setPosition(static_cast<float>(pos.x) * core::Properties::PixelsPerTile(),
+                             static_cast<float>(pos.y) * core::Properties::PixelsPerTile());
+            area.setSize({static_cast<float>(size.x) * core::Properties::PixelsPerTile(),
+                          static_cast<float>(size.y) * core::Properties::PixelsPerTile()});
+            target.draw(area);
+        }
+    } break;
 
     case RenderOverlay::PeoplemonZones:
         // TODO

--- a/src/Editor/Components/EditMap.cpp
+++ b/src/Editor/Components/EditMap.cpp
@@ -382,6 +382,18 @@ void EditMap::shiftLevel(unsigned int level, bool up) {
 
 void EditMap::appendLevel() { addAction(AppendLevelAction::create()); }
 
+void EditMap::setOnEnterScript(const std::string& s) {
+    addAction(SetScriptAction::create(true, s, loadScriptField.getValue()));
+}
+
+const std::string& EditMap::getOnEnterScript() const { return loadScriptField.getValue(); }
+
+void EditMap::setOnExitScript(const std::string& s) {
+    addAction(SetScriptAction::create(false, s, unloadScriptField.getValue()));
+}
+
+const std::string& EditMap::getOnExitScript() const { return unloadScriptField.getValue(); }
+
 void EditMap::render(sf::RenderTarget& target, float residual,
                      const EntityRenderCallback& entityCb) const {
     const sf::View& view = target.getView();

--- a/src/Editor/Components/EditMap.cpp
+++ b/src/Editor/Components/EditMap.cpp
@@ -534,5 +534,25 @@ void EditMap::render(sf::RenderTarget& target, float residual,
     }
 }
 
+void EditMap::createEvent(const core::map::Event& event) {
+    // TODO
+}
+
+const core::map::Event* EditMap::getEvent(const sf::Vector2i& tiles) {
+    for (const core::map::Event& event : eventsField.getValue()) {
+        const sf::IntRect area(event.position, event.areaSize);
+        if (area.contains(tiles)) return &event;
+    }
+    return nullptr;
+}
+
+void EditMap::editEvent(const core::map::Event* orig, const core::map::Event& val) {
+    // TODO
+}
+
+void EditMap::removeEvent(const core::map::Event* e) {
+    // TODO
+}
+
 } // namespace component
 } // namespace editor

--- a/src/Editor/Components/EditMap.cpp
+++ b/src/Editor/Components/EditMap.cpp
@@ -535,7 +535,7 @@ void EditMap::render(sf::RenderTarget& target, float residual,
 }
 
 void EditMap::createEvent(const core::map::Event& event) {
-    // TODO
+    addAction(AddEventAction::create(event, eventsField.getValue().size()));
 }
 
 const core::map::Event* EditMap::getEvent(const sf::Vector2i& tiles) {
@@ -547,11 +547,15 @@ const core::map::Event* EditMap::getEvent(const sf::Vector2i& tiles) {
 }
 
 void EditMap::editEvent(const core::map::Event* orig, const core::map::Event& val) {
-    // TODO
+    unsigned int i = 0;
+    while (&eventsField.getValue()[i] != orig) { ++i; }
+    addAction(EditEventAction::create(*orig, val, i));
 }
 
 void EditMap::removeEvent(const core::map::Event* e) {
-    // TODO
+    unsigned int i = 0;
+    while (&eventsField.getValue()[i] != e) { ++i; }
+    addAction(RemoveEventAction::create(*e, i));
 }
 
 } // namespace component

--- a/src/Editor/Components/EventEditor.cpp
+++ b/src/Editor/Components/EventEditor.cpp
@@ -65,7 +65,10 @@ EventEditor::EventEditor(const OnEdit& oe)
     row                 = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
     Button::Ptr editBut = Button::create("Confirm");
     editBut->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
-        if (valid()) { onEdit(orig, makeEvent()); }
+        if (valid()) {
+            onEdit(orig, makeEvent());
+            window->remove();
+        }
     });
     row->pack(editBut, false, true);
     Button::Ptr cancelBut = Button::create("Cancel");

--- a/src/Editor/Components/EventEditor.cpp
+++ b/src/Editor/Components/EventEditor.cpp
@@ -1,0 +1,148 @@
+#include <Editor/Components/EventEditor.hpp>
+
+namespace editor
+{
+namespace component
+{
+using namespace bl::gui;
+
+EventEditor::EventEditor(const OnEdit& oe)
+: onEdit(oe)
+, scriptSelector(std::bind(&EventEditor::onScriptChosen, this, std::placeholders::_1)) {
+    window = Window::create(LinePacker::create(LinePacker::Vertical, 10), "Event Editor");
+    window->getSignal(Action::Closed).willAlwaysCall([this](const Action&, Element*) {
+        window->remove();
+    });
+
+    Box::Ptr row = Box::create(LinePacker::create(LinePacker::Horizontal, 8));
+    scriptLabel  = Label::create("");
+    scriptLabel->setColor(sf::Color::Blue, sf::Color::Transparent);
+    row->pack(scriptLabel, true, true);
+    Button::Ptr pickButton = Button::create("Pick/Edit Script");
+    pickButton->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        scriptSelector.open(parent, scriptLabel->getText());
+    });
+    row->pack(pickButton, false, true);
+    window->pack(row, true, false);
+
+    row            = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
+    Box::Ptr input = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
+    input->pack(Label::create("X:"), false, true);
+    xInput = TextEntry::create();
+    input->pack(xInput, true, true);
+    row->pack(input, true, true);
+    input = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
+    input->pack(Label::create("Y:"), false, true);
+    yInput = TextEntry::create();
+    input->pack(yInput, true, true);
+    row->pack(input, true, true);
+    window->pack(row, true, false);
+
+    row   = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
+    input = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
+    input->pack(Label::create("W:"), false, true);
+    wInput = TextEntry::create();
+    input->pack(wInput, true, true);
+    row->pack(input, true, true);
+    input = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
+    input->pack(Label::create("H:"), false, true);
+    hInput = TextEntry::create();
+    input->pack(hInput, true, true);
+    row->pack(input, true, true);
+    window->pack(row, true, false);
+
+    row           = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
+    triggerSelect = ComboBox::create();
+    triggerSelect->addOption("OnEnter");
+    triggerSelect->addOption("OnExit");
+    triggerSelect->addOption("OnEnterOrExit");
+    triggerSelect->addOption("WhileIn");
+    triggerSelect->addOption("OnInteract");
+    row->pack(Label::create("Trigger:"), false, true);
+    row->pack(triggerSelect, false, true);
+    window->pack(row, true, false);
+
+    row                 = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
+    Button::Ptr editBut = Button::create("Confirm");
+    editBut->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        if (valid()) { onEdit(orig, makeEvent()); }
+    });
+    row->pack(editBut, false, true);
+    Button::Ptr cancelBut = Button::create("Cancel");
+    cancelBut->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        window->remove();
+    });
+    row->pack(cancelBut, false, true);
+    window->pack(row, true, false);
+}
+
+void EventEditor::open(const GUI::Ptr& p, const core::map::Event* source,
+                       const sf::Vector2i& tiles) {
+    parent = p;
+    p->pack(window);
+    orig = source;
+
+    if (source) {
+        scriptLabel->setText(source->script.getValue());
+        xInput->setInput(std::to_string(source->position.getValue().x));
+        yInput->setInput(std::to_string(source->position.getValue().y));
+        wInput->setInput(std::to_string(source->areaSize.getValue().x));
+        hInput->setInput(std::to_string(source->areaSize.getValue().y));
+        triggerSelect->setSelectedOption(static_cast<int>(source->trigger.getValue()) - 1);
+    }
+    else {
+        scriptLabel->setText("");
+        xInput->setInput(std::to_string(tiles.x));
+        yInput->setInput(std::to_string(tiles.y));
+        wInput->setInput("1");
+        hInput->setInput("1");
+        triggerSelect->setSelectedOption(0);
+    }
+}
+
+bool EventEditor::valid() const {
+    const auto isNum = [](const std::string& s) -> bool {
+        for (const char c : s) {
+            if (c < '0' || c > '9') return false;
+        }
+        return true;
+    };
+
+    const auto err = [](const std::string& e) {
+        bl::dialog::tinyfd_messageBox("Error", e.c_str(), "ok", "error", 1);
+    };
+
+    if (!isNum(xInput->getInput())) {
+        err("X tile position is invalid");
+        return false;
+    }
+    if (!isNum(yInput->getInput())) {
+        err("Y tile position is invalid");
+        return false;
+    }
+    if (!isNum(wInput->getInput())) {
+        err("Region tile width is invalid");
+        return false;
+    }
+    if (!isNum(hInput->getInput())) {
+        err("Region tile height is invalid");
+        return false;
+    }
+    return true;
+}
+
+core::map::Event EventEditor::makeEvent() const {
+    core::map::Event e;
+    e.script                = scriptLabel->getText();
+    e.position.getValue().x = std::atoi(xInput->getInput().c_str());
+    e.position.getValue().y = std::atoi(yInput->getInput().c_str());
+    e.areaSize.getValue().x = std::atoi(wInput->getInput().c_str());
+    e.areaSize.getValue().y = std::atoi(hInput->getInput().c_str());
+    e.trigger = static_cast<core::map::Event::Trigger>(triggerSelect->getSelectedOption() + 1);
+    return e;
+}
+
+void EventEditor::onScriptChosen(const std::string& s) { scriptLabel->setText(s); }
+
+} // namespace component
+} // namespace editor

--- a/src/Editor/Components/MapActions.cpp
+++ b/src/Editor/Components/MapActions.cpp
@@ -677,5 +677,36 @@ bool EditMap::AppendLevelAction::undo(EditMap& map) {
 
 const char* EditMap::AppendLevelAction::description() const { return "add level"; }
 
+EditMap::Action::Ptr EditMap::SetScriptAction::create(bool l, const std::string& s,
+                                                      const std::string& p) {
+    return Ptr(new SetScriptAction(l, s, p));
+}
+
+EditMap::SetScriptAction::SetScriptAction(bool l, const std::string& s, const std::string& p)
+: load(l)
+, s(s)
+, p(p) {}
+
+bool EditMap::SetScriptAction::apply(EditMap& map) {
+    if (load) { map.loadScriptField = s; }
+    else {
+        map.unloadScriptField = s;
+    }
+    return true;
+}
+
+bool EditMap::SetScriptAction::undo(EditMap& map) {
+    if (load) { map.loadScriptField = p; }
+    else {
+        map.unloadScriptField = p;
+    }
+    return true;
+}
+
+const char* EditMap::SetScriptAction::description() const {
+    if (load) { return "set load script"; }
+    return "set unload script";
+}
+
 } // namespace component
 } // namespace editor

--- a/src/Editor/Components/MapActions.cpp
+++ b/src/Editor/Components/MapActions.cpp
@@ -708,5 +708,68 @@ const char* EditMap::SetScriptAction::description() const {
     return "set unload script";
 }
 
+EditMap::Action::Ptr EditMap::AddEventAction::create(const core::map::Event& e, unsigned int i) {
+    return Ptr(new AddEventAction(e, i));
+}
+
+EditMap::AddEventAction::AddEventAction(const core::map::Event& e, unsigned int i)
+: event(e)
+, i(i) {}
+
+bool EditMap::AddEventAction::apply(EditMap& map) {
+    map.eventsField.getValue().emplace_back(event);
+    return false;
+}
+
+bool EditMap::AddEventAction::undo(EditMap& map) {
+    map.eventsField.getValue().erase(map.eventsField.getValue().begin() + i);
+    return false;
+}
+
+const char* EditMap::AddEventAction::description() const { return "add event"; }
+
+EditMap::Action::Ptr EditMap::EditEventAction::create(const core::map::Event& o,
+                                                      const core::map::Event& e, unsigned int i) {
+    return Ptr(new EditEventAction(o, e, i));
+}
+
+EditMap::EditEventAction::EditEventAction(const core::map::Event& o, const core::map::Event& e,
+                                          unsigned int i)
+: orig(o)
+, val(e)
+, i(i) {}
+
+bool EditMap::EditEventAction::apply(EditMap& map) {
+    map.eventsField.getValue()[i] = val;
+    return false;
+}
+
+bool EditMap::EditEventAction::undo(EditMap& map) {
+    map.eventsField.getValue()[i] = orig;
+    return false;
+}
+
+const char* EditMap::EditEventAction::description() const { return "edit event"; }
+
+EditMap::Action::Ptr EditMap::RemoveEventAction::create(const core::map::Event& e, unsigned int i) {
+    return Ptr(new RemoveEventAction(e, i));
+}
+
+EditMap::RemoveEventAction::RemoveEventAction(const core::map::Event& e, unsigned int i)
+: event(e)
+, i(i) {}
+
+bool EditMap::RemoveEventAction::apply(EditMap& map) {
+    map.eventsField.getValue().erase(map.eventsField.getValue().begin() + i);
+    return false;
+}
+
+bool EditMap::RemoveEventAction::undo(EditMap& map) {
+    map.eventsField.getValue().insert(map.eventsField.getValue().begin() + i, event);
+    return false;
+}
+
+const char* EditMap::RemoveEventAction::description() const { return "remove event"; }
+
 } // namespace component
 } // namespace editor

--- a/src/Editor/Components/MapActions.hpp
+++ b/src/Editor/Components/MapActions.hpp
@@ -271,6 +271,50 @@ private:
     SetScriptAction(bool load, const std::string& s, const std::string& p);
 };
 
+class EditMap::AddEventAction : public EditMap::Action {
+public:
+    static Action::Ptr create(const core::map::Event& e, unsigned int i);
+
+    virtual ~AddEventAction() = default;
+    virtual bool apply(EditMap& map) override;
+    virtual bool undo(EditMap& map) override;
+    virtual const char* description() const override;
+
+private:
+    const core::map::Event event;
+    const unsigned int i;
+};
+
+class EditMap::EditEventAction : public EditMap::Action {
+public:
+    static Action::Ptr create(const core::map::Event& orig, const core::map::Event& val,
+                              unsigned int i);
+
+    virtual ~EditEventAction() = default;
+    virtual bool apply(EditMap& map) override;
+    virtual bool undo(EditMap& map) override;
+    virtual const char* description() const override;
+
+private:
+    const core::map::Event orig;
+    const core::map::Event val;
+    const unsigned int i;
+};
+
+class EditMap::RemoveEventAction : public EditMap::Action {
+public:
+    static Action::Ptr create(const core::map::Event& e, unsigned int i);
+
+    virtual ~RemoveEventAction() = default;
+    virtual bool apply(EditMap& map) override;
+    virtual bool undo(EditMap& map) override;
+    virtual const char* description() const override;
+
+private:
+    const core::map::Event event;
+    const unsigned int i;
+};
+
 } // namespace component
 } // namespace editor
 

--- a/src/Editor/Components/MapActions.hpp
+++ b/src/Editor/Components/MapActions.hpp
@@ -283,6 +283,8 @@ public:
 private:
     const core::map::Event event;
     const unsigned int i;
+
+    AddEventAction(const core::map::Event& e, unsigned int i);
 };
 
 class EditMap::EditEventAction : public EditMap::Action {
@@ -299,6 +301,8 @@ private:
     const core::map::Event orig;
     const core::map::Event val;
     const unsigned int i;
+
+    EditEventAction(const core::map::Event& orig, const core::map::Event& val, unsigned int i);
 };
 
 class EditMap::RemoveEventAction : public EditMap::Action {
@@ -313,6 +317,8 @@ public:
 private:
     const core::map::Event event;
     const unsigned int i;
+
+    RemoveEventAction(const core::map::Event& orig, unsigned int i);
 };
 
 } // namespace component

--- a/src/Editor/Components/MapActions.hpp
+++ b/src/Editor/Components/MapActions.hpp
@@ -254,6 +254,23 @@ private:
     AppendLevelAction() = default;
 };
 
+class EditMap::SetScriptAction : public EditMap::Action {
+public:
+    static EditMap::Action::Ptr create(bool load, const std::string& s, const std::string& p);
+
+    virtual ~SetScriptAction() = default;
+    virtual bool apply(EditMap& map) override;
+    virtual bool undo(EditMap& map) override;
+    virtual const char* description() const override;
+
+private:
+    const bool load;
+    const std::string s;
+    const std::string p;
+
+    SetScriptAction(bool load, const std::string& s, const std::string& p);
+};
+
 } // namespace component
 } // namespace editor
 

--- a/src/Editor/Components/ScriptSelector.cpp
+++ b/src/Editor/Components/ScriptSelector.cpp
@@ -1,5 +1,6 @@
 #include <Editor/Components/ScriptSelector.hpp>
 
+#include <BLIB/Scripts.hpp>
 #include <Core/Properties.hpp>
 
 namespace editor
@@ -15,6 +16,9 @@ ScriptSelector::ScriptSelector(const OnSelect& os)
          std::bind(&ScriptSelector::onPick, this, std::placeholders::_1),
          [this]() { picker.close(); }) {
     window = Window::create(LinePacker::create(LinePacker::Vertical, 4), "Select Script");
+    window->getSignal(Action::Closed).willAlwaysCall([this](const Action&, Element*) {
+        window->remove();
+    });
 
     Button::Ptr pickBut = Button::create("Pick File");
     pickBut->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
@@ -24,7 +28,7 @@ ScriptSelector::ScriptSelector(const OnSelect& os)
 
     scriptInput = TextEntry::create();
     scriptInput->setRequisition({250, 1});
-    scriptInput->getSignal(Action::ValueChanged).willAlwaysCall([this](const Action&, Element*) {
+    scriptInput->getSignal(Action::TextEntered).willAlwaysCall([this](const Action&, Element*) {
         checkSyntax();
     });
     window->pack(scriptInput, true, false);
@@ -60,7 +64,15 @@ void ScriptSelector::onPick(const std::string& s) {
 }
 
 void ScriptSelector::checkSyntax() {
-    // TODO
+    bl::script::Script script(scriptInput->getInput());
+    if (script.valid()) {
+        errorLabel->setText("No error");
+        errorLabel->setColor(sf::Color::Green, sf::Color::Transparent);
+    }
+    else {
+        errorLabel->setText(script.errorMessage());
+        errorLabel->setColor(sf::Color::Red, sf::Color::Transparent);
+    }
 }
 
 } // namespace component

--- a/src/Editor/Components/ScriptSelector.cpp
+++ b/src/Editor/Components/ScriptSelector.cpp
@@ -60,6 +60,7 @@ void ScriptSelector::open(const GUI::Ptr& p, const std::string& s) {
 
 void ScriptSelector::onPick(const std::string& s) {
     scriptInput->setInput(s);
+    picker.close();
     checkSyntax();
 }
 

--- a/src/Editor/Components/ScriptSelector.cpp
+++ b/src/Editor/Components/ScriptSelector.cpp
@@ -1,0 +1,67 @@
+#include <Editor/Components/ScriptSelector.hpp>
+
+#include <Core/Properties.hpp>
+
+namespace editor
+{
+namespace component
+{
+using namespace bl::gui;
+
+ScriptSelector::ScriptSelector(const OnSelect& os)
+: onSelect(os)
+, error(false)
+, picker(core::Properties::ScriptPath(), {"psc", "bs"},
+         std::bind(&ScriptSelector::onPick, this, std::placeholders::_1),
+         [this]() { picker.close(); }) {
+    window = Window::create(LinePacker::create(LinePacker::Vertical, 4), "Select Script");
+
+    Button::Ptr pickBut = Button::create("Pick File");
+    pickBut->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        picker.open(FilePicker::PickExisting, "Pick Script", parent, false);
+    });
+    window->pack(pickBut);
+
+    scriptInput = TextEntry::create();
+    scriptInput->setRequisition({250, 1});
+    scriptInput->getSignal(Action::ValueChanged).willAlwaysCall([this](const Action&, Element*) {
+        checkSyntax();
+    });
+    window->pack(scriptInput, true, false);
+
+    errorLabel = Label::create("");
+    window->pack(errorLabel, true, false);
+
+    Box::Ptr row       = Box::create(LinePacker::create(LinePacker::Horizontal, 10));
+    Button::Ptr choose = Button::create("Select");
+    choose->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        onSelect(scriptInput->getInput());
+        window->remove();
+    });
+    row->pack(choose, false, true);
+    Button::Ptr cancel = Button::create("Cancel");
+    cancel->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        window->remove();
+    });
+    row->pack(cancel, false, true);
+    window->pack(row, true, false);
+}
+
+void ScriptSelector::open(const GUI::Ptr& p, const std::string& s) {
+    parent = p;
+    scriptInput->setInput(s);
+    parent->pack(window);
+    checkSyntax();
+}
+
+void ScriptSelector::onPick(const std::string& s) {
+    scriptInput->setInput(s);
+    checkSyntax();
+}
+
+void ScriptSelector::checkSyntax() {
+    // TODO
+}
+
+} // namespace component
+} // namespace editor

--- a/src/Editor/Pages/Map.cpp
+++ b/src/Editor/Pages/Map.cpp
@@ -50,6 +50,7 @@ Map::Map(core::system::Systems& s)
     Box::Ptr mapCtrlBox   = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
     Button::Ptr newMapBut = Button::create("New Map");
     newMapBut->getSignal(Action::LeftClicked).willCall([this](const Action&, Element*) {
+        mapArea.disableControls();
         if (checkUnsaved()) {
             makingNewMap = true;
             mapPicker.open(FilePicker::CreateNew, "New map", parent);
@@ -57,6 +58,7 @@ Map::Map(core::system::Systems& s)
     });
     Button::Ptr loadMapBut = Button::create("Load Map");
     loadMapBut->getSignal(Action::LeftClicked).willCall([this](const Action&, Element*) {
+        mapArea.disableControls();
         if (checkUnsaved()) {
             makingNewMap = false;
             mapPicker.open(FilePicker::PickExisting, "Load map", parent);
@@ -142,6 +144,7 @@ Map::Map(core::system::Systems& s)
     playlistLabel               = Label::create("playerlistFile.bplst");
     Button::Ptr pickPlaylistBut = Button::create("Pick Playlist");
     pickPlaylistBut->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        mapArea.disableControls();
         playlistPicker.open(FilePicker::PickExisting, "Select Playlist", parent);
     });
     playlistLabel->setHorizontalAlignment(RenderSettings::Left);
@@ -287,12 +290,14 @@ Map::Map(core::system::Systems& s)
     row                    = Box::create(LinePacker::create(LinePacker::Horizontal, 4));
     Button::Ptr pickButton = Button::create("Set OnEnter");
     pickButton->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        mapArea.disableControls();
         choosingOnloadScript = true;
         scriptSelector.open(parent, mapArea.editMap().getOnEnterScript());
     });
     row->pack(pickButton);
     pickButton = Button::create("Set OnExit");
     pickButton->getSignal(Action::LeftClicked).willAlwaysCall([this](const Action&, Element*) {
+        mapArea.disableControls();
         choosingOnloadScript = false;
         scriptSelector.open(parent, mapArea.editMap().getOnExitScript());
     });
@@ -570,8 +575,12 @@ void Map::onMapClick(const sf::Vector2f&, const sf::Vector2i& tiles) {
         break;
 
     case Tool::Events:
-        if (createEventRadio->getValue()) { eventEditor.open(parent, nullptr, tiles); }
+        if (createEventRadio->getValue()) {
+            mapArea.disableControls();
+            eventEditor.open(parent, nullptr, tiles);
+        }
         else if (editEventRadio->getValue()) {
+            mapArea.disableControls();
             const core::map::Event* e = mapArea.editMap().getEvent(tiles);
             if (e) { eventEditor.open(parent, e, tiles); }
         }
@@ -680,6 +689,7 @@ void Map::onEventEdit(const core::map::Event* orig, const core::map::Event& val)
     else {
         mapArea.editMap().createEvent(val);
     }
+    mapArea.enableControls();
 }
 
 } // namespace page

--- a/src/Editor/Pages/Subpages/MapArea.cpp
+++ b/src/Editor/Pages/Subpages/MapArea.cpp
@@ -33,7 +33,7 @@ MapArea::MapArea(const component::EditMap::PositionCb& cb,
 
     Box::Ptr rightSide = Box::create(
         LinePacker::create(LinePacker::Horizontal, 4, LinePacker::Compact, LinePacker::RightAlign));
-    CheckButton::Ptr enableBut = CheckButton::create("Enable Map Controls");
+    enableBut = CheckButton::create("Enable Map Controls");
     enableBut->getSignal(Action::ValueChanged).willAlwaysCall([this](const Action& a, Element*) {
         map->setControlsEnabled(a.data.bvalue);
     });
@@ -76,6 +76,16 @@ void MapArea::refreshButtons() {
 void MapArea::onMouseOver(const sf::Vector2f&, const sf::Vector2i& tiles) {
     positionLabel->setText("Tile: (" + std::to_string(tiles.x) + ", " + std::to_string(tiles.y) +
                            ")");
+}
+
+void MapArea::disableControls() {
+    editMap().setControlsEnabled(false);
+    enableBut->setValue(false);
+}
+
+void MapArea::enableControls() {
+    editMap().setControlsEnabled(true);
+    enableBut->setValue(true);
 }
 
 } // namespace page

--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -26,6 +26,7 @@ int main() {
             .withWindowStyle(sf::Style::Close | sf::Style::Titlebar | sf::Style::Resize)
             .withWindowTitle("Peoplemon Editor")
             .withWindowIcon("EditorResources/icon.png")
+            .withAllowVariableTimestep(false)
             .fromConfig();
     bl::engine::Engine engine(engineSettings);
     BL_LOG_INFO << "Created engine";


### PR DESCRIPTION
Now able to edit map events, including on enter and exit as well as tile based scripts.

Resolves #52 